### PR TITLE
Add gun and SEA to Griffin's return object

### DIFF
--- a/core/lib/index.js
+++ b/core/lib/index.js
@@ -163,6 +163,8 @@ function Griffin(options) {
 		delete: delete_,
 		online,
 		namespace,
+		gun,
+		SEA,
 	}
 }
 


### PR DESCRIPTION
Does this make sense so people can easily get at the gun or SEA constructors if they need/want?